### PR TITLE
Added Resources for Go Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ See [Go Books](https://github.com/dariubs/GoBooks) for a longer list of books, b
 - [Lesser-Known Features of Go Test](https://splice.com/blog/lesser-known-features-go-test/)
 - [When Writing Unit Tests, Don’t Use Mocks](https://sendgrid.com/blog/when-writing-unit-tests-dont-use-mocks/)
 
+### Dependency Management
+- [An Intro to dependency management with Go](https://medium.freecodecamp.org/an-intro-to-dep-how-to-manage-your-golang-project-dependencies-7b07d84e7ba5)
+- [Go Modules (Introduced experimentally in Go 1.11.0)](https://github.com/golang/go/wiki/Modules)
+
 ### Web
 
 - [Exposing Go on the Internet](https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See [Go Books](https://github.com/dariubs/GoBooks) for a longer list of books, b
 - [Package names](https://blog.golang.org/package-names)
 - [For Range Semantics](https://www.ardanlabs.com/blog/2017/06/for-range-semantics.html)
 - [How to use interfaces in Go](http://jordanorelli.com/post/32665860244/how-to-use-interfaces-in-go)
-- [Introduction to Go modules](https://roberto.selbach.ca/intro-to-go-modules/)
+
 
 ### Web
 
@@ -157,10 +157,10 @@ See [Go Books](https://github.com/dariubs/GoBooks) for a longer list of books, b
 - [Lesser-Known Features of Go Test](https://splice.com/blog/lesser-known-features-go-test/)
 - [When Writing Unit Tests, Don’t Use Mocks](https://sendgrid.com/blog/when-writing-unit-tests-dont-use-mocks/)
 
-### Dependency Management
-- [An Intro to dependency management with Go](https://medium.freecodecamp.org/an-intro-to-dep-how-to-manage-your-golang-project-dependencies-7b07d84e7ba5)
+### Go Modules
+
 - [Go Modules (Introduced experimentally in Go 1.11.0)](https://github.com/golang/go/wiki/Modules)
-- [A gentle introduction to Go Modules](https://ukiahsmith.com/blog/a-gentle-introduction-to-golang-modules/)
+- [Introduction to Go modules](https://roberto.selbach.ca/intro-to-go-modules/)
 
 ### Web
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See [Go Books](https://github.com/dariubs/GoBooks) for a longer list of books, b
 ### Dependency Management
 - [An Intro to dependency management with Go](https://medium.freecodecamp.org/an-intro-to-dep-how-to-manage-your-golang-project-dependencies-7b07d84e7ba5)
 - [Go Modules (Introduced experimentally in Go 1.11.0)](https://github.com/golang/go/wiki/Modules)
+- [A gentle introduction to Go Modules](https://ukiahsmith.com/blog/a-gentle-introduction-to-golang-modules/)
 
 ### Web
 


### PR DESCRIPTION
As discussed in PR #82, I have added a separate section for  Go Modules and moved the links to the Go Modules wiki and the link that was previously in Organization And Style to the new Go Modules section.