### PR TITLE
Configure CircleCI build to check links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.1
+    working_directory: ~/gopher-reading-list
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-gem-cache-{{ .Branch }}
+            - v1-gem-cache-
+      - run: gem install awesome_bot --user-install
+      - save_cache:
+          key: v1-gem-cache-{{ .Branch }}
+          paths:
+            - "/usr/local/bundle/"
+      - run: awesome_bot --allow-redirect --allow-dupe README.md

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,3 +16,8 @@ jobs:
           paths:
             - "/usr/local/bundle/*"
       - run: awesome_bot --allow-redirect --allow-dupe README.md
+      - store_artifacts:
+          path: ab-results-README.md.json
+      - store_artifacts:
+          path: ab-results-README.md-markdown-table.json
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-gem-cache-{{ .Branch }}
-            - v1-gem-cache-
-      - run: gem install awesome_bot --user-install
+            - v1.1-gem-cache-{{ .Branch }}
+            - v1.1-gem-cache-
+      - run: gem install awesome_bot
       - save_cache:
-          key: v1-gem-cache-{{ .Branch }}
+          key: v1.1-gem-cache-{{ .Branch }}
           paths:
-            - "/usr/local/bundle/"
+            - "/usr/local/bundle/*"
       - run: awesome_bot --allow-redirect --allow-dupe README.md


### PR DESCRIPTION
To onboard:

1. Go to circleci.com and login w/ Github.
2. Go to "Add Project" on the left side and add this project. This will automatically setup the webhooks for you.
3. Click "Start Building" and you'll see it fail because by default it will kick off a build on your master branch, which doesn't have this config file yet.
4. Here is [a link to the build on my fork](https://circleci.com/gh/mvxt/gopher-reading-list/6), which confirms it's working.
5. Once you merge this PR in, then it will build on your master branch.

Let me know if you have any questions.

By the way, the build on CircleCI runs in ~8-10 seconds. Way faster than the 1 minute Travis took.

NOTE: I didn't remove .travis.yml in this PR, I figure I'll let you handle that if you decide you like this better.